### PR TITLE
chore: remove app-example/ and .gitignore entry (T1.1.1, T1.1.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-app-example
-
 # generated native folders
 /ios
 /android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+### Removed
+
+- **2026-05-02** — Deleted leftover Expo template directory `app-example/` and removed its `.gitignore` entry (completes T1.1.1, T1.1.2).
+
 ### Added
 
 - **2026-05-02** — `CHANGELOG.md` and `PROJECT_STATUS.md` to track project history and milestone progress.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -5,7 +5,7 @@
 
 **Last updated:** 2026-05-02
 **Current phase:** Phase 1 — Foundation (in progress, ~20% complete)
-**Overall MVP progress:** ~5% (4 / 80 tasks complete)
+**Overall MVP progress:** ~8% (6 / 80 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
 
@@ -16,7 +16,7 @@
 | Phase | Focus | Status | Progress |
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
-| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~20% |
+| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~25% |
 | **2** | Core gameplay — playable round end-to-end | ⏳ Not started | 0% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
@@ -46,6 +46,8 @@ Pre-MVP setup that happened before the formal phase plan was written. Captured h
 
 ### Accomplished
 
+- [x] **T1.1.1** — `app-example/` directory deleted.
+- [x] **T1.1.2** — `app-example` entry removed from `.gitignore`.
 - [x] **T1.1.4** — `tsconfig.json` path alias `@/*` verified working.
 - [x] **T1.7.1 (partial)** — Empty placeholder folders for `src/features/` and `src/shared/store|context|hooks|components` exist with `.gitkeep`.
 
@@ -53,13 +55,12 @@ Pre-MVP setup that happened before the formal phase plan was written. Captured h
 
 These should be tackled first to unblock Phase 2:
 
-1. **T1.1.1** — Delete `app-example/` directory.
-2. **T1.2.1–T1.2.7** — Install runtime deps: `zustand`, `@react-native-async-storage/async-storage`, `expo-audio`, `expo-haptics`, `react-native-reanimated`, `zod`, `uuid` + `react-native-get-random-values`.
-3. **T1.3.1–T1.3.5** — Install dev deps and add `jest-expo` test runner.
-4. **T1.4.1–T1.4.3** — Create `src/shared/constants/theme.ts` with color/spacing/radii/type tokens.
-5. **T1.5.1–T1.5.4** — Expand `en.json` and `fr.json` to cover all MVP UI copy; add `i18n.d.ts` for typed `t()` keys.
-6. **T1.6.1–T1.6.4** — Create `Button`, `ScreenContainer`, `SegmentedControl` shared components.
-7. **T1.7.1–T1.7.3** — Stub the `src/features/game/` tree (components, hooks, lib, store, types).
+1. **T1.2.1–T1.2.7** — Install runtime deps: `zustand`, `@react-native-async-storage/async-storage`, `expo-audio`, `expo-haptics`, `react-native-reanimated`, `zod`, `uuid` + `react-native-get-random-values`.
+2. **T1.3.1–T1.3.5** — Install dev deps and add `jest-expo` test runner.
+3. **T1.4.1–T1.4.3** — Create `src/shared/constants/theme.ts` with color/spacing/radii/type tokens.
+4. **T1.5.1–T1.5.4** — Expand `en.json` and `fr.json` to cover all MVP UI copy; add `i18n.d.ts` for typed `t()` keys.
+5. **T1.6.1–T1.6.4** — Create `Button`, `ScreenContainer`, `SegmentedControl` shared components.
+6. **T1.7.1–T1.7.3** — Stub the `src/features/game/` tree (components, hooks, lib, store, types).
 
 ### Definition of Done (Phase 1)
 


### PR DESCRIPTION
## Summary

- Deleted the leftover Expo template directory `app-example/` — unused, unimported, and confusing to navigation
- Removed the `app-example` entry from `.gitignore` (no longer needed once the dir is gone)
- Updated `PROJECT_STATUS.md`: T1.1.1 + T1.1.2 marked done, Phase 1 progress → ~25%, overall MVP → ~8% (6/80)
- Updated `CHANGELOG.md`: added `### Removed` entry under `[Unreleased]`

## Test plan

- [ ] `ls app-example` → "No such file or directory"
- [ ] `grep app-example .gitignore` → no output
- [ ] `npx tsc --noEmit` passes
- [ ] App still launches with `pnpm start`

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)