### PR TITLE
chore: confirm expo-haptics installed (T1.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — `expo-haptics ~15.0.8` confirmed present (SDK 54 default template); no additional install required (completes T1.2.4).
 - **2026-05-02** — Installed `expo-audio ~1.1.1` (SDK 54 compatible) and registered its plugin in `app.json` (completes T1.2.3).
 - **2026-05-02** — Installed `@react-native-async-storage/async-storage ^3.0.2` as a runtime dependency (completes T1.2.2).
 - **2026-05-02** — Installed `zustand ^5.0.12` as a runtime dependency (completes T1.2.1).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,7 +4,7 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 1 — Foundation (in progress, ~29% complete)
+**Current phase:** Phase 1 — Foundation (in progress, ~33% complete)
 **Overall MVP progress:** ~11% (9 / 80 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
@@ -16,7 +16,7 @@
 | Phase | Focus | Status | Progress |
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
-| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~29% |
+| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~33% |
 | **2** | Core gameplay — playable round end-to-end | ⏳ Not started | 0% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
@@ -53,6 +53,7 @@ Pre-MVP setup that happened before the formal phase plan was written. Captured h
 - [x] **T1.2.1** — `zustand` installed.
 - [x] **T1.2.2** — `@react-native-async-storage/async-storage` installed.
 - [x] **T1.2.3** — `expo-audio` installed.
+- [x] **T1.2.4** — `expo-haptics` installed.
 
 ### Up next (immediate)
 


### PR DESCRIPTION
## Summary

- `expo-haptics ~15.0.8` was already present in `package.json` (included by the Expo SDK 54 default template)
- `pnpm install` and `npx tsc --noEmit` both pass with no changes required
- `PROJECT_STATUS.md` and `CHANGELOG.md` updated to record T1.2.4 as complete

## Task

Implements **T1.2.4** from the Mathify MVP roadmap (Phase 1 — Foundation).
Full acceptance criteria are defined in [planned.md](planned.md).

## Acceptance criteria

- [x] `expo-haptics` is present in `dependencies` (installed via the SDK 54 template)
- [x] `pnpm install` exits 0
- [x] `npx tsc --noEmit` passes

## Test plan

- [x] `pnpm install` exits 0
- [x] `npx tsc --noEmit` passes
- [x] `expo-haptics` entry confirmed in `package.json`

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible)
- [x] No third-party SDKs added beyond task scope
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T1.2.4** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)