### PR TITLE
chore: confirm react-native-reanimated installed (T1.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — `react-native-reanimated ~4.1.1` confirmed present (SDK 54 default template); Expo SDK 54 + New Architecture handles reanimated v4 automatically — no Babel plugin entry required (completes T1.2.5).
 - **2026-05-02** — `expo-haptics ~15.0.8` confirmed present (SDK 54 default template); no additional install required (completes T1.2.4).
 - **2026-05-02** — Installed `expo-audio ~1.1.1` (SDK 54 compatible) and registered its plugin in `app.json` (completes T1.2.3).
 - **2026-05-02** — Installed `@react-native-async-storage/async-storage ^3.0.2` as a runtime dependency (completes T1.2.2).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,7 +4,7 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 1 — Foundation (in progress, ~33% complete)
+**Current phase:** Phase 1 — Foundation (in progress, ~38% complete)
 **Overall MVP progress:** ~11% (9 / 80 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
@@ -16,7 +16,7 @@
 | Phase | Focus | Status | Progress |
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
-| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~33% |
+| **1** | Foundation — deps, theme, locales, skeleton | 🟡 In progress | ~38% |
 | **2** | Core gameplay — playable round end-to-end | ⏳ Not started | 0% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
@@ -54,6 +54,7 @@ Pre-MVP setup that happened before the formal phase plan was written. Captured h
 - [x] **T1.2.2** — `@react-native-async-storage/async-storage` installed.
 - [x] **T1.2.3** — `expo-audio` installed.
 - [x] **T1.2.4** — `expo-haptics` installed.
+- [x] **T1.2.5** — `react-native-reanimated` installed; Babel plugin not required (Expo SDK 54 + New Arch handles reanimated v4 automatically).
 
 ### Up next (immediate)
 


### PR DESCRIPTION
## Summary

- `react-native-reanimated ~4.1.1` confirmed present in `package.json` (Expo SDK 54 default template)
- No `babel.config.js` exists — Expo SDK 54 with `reactCompiler: true` + `newArchEnabled: true` handles reanimated v4 automatically; no `'react-native-reanimated/plugin'` entry is required
- `react-native-worklets 0.5.1` also present (reanimated v4 worklets runtime)

## Task

Implements **T1.2.5** from the Mathify MVP roadmap (Phase 1 — Foundation).
Full acceptance criteria are defined in [planned.md](planned.md).

## Acceptance criteria

- [x] `react-native-reanimated` present in `dependencies`
- [x] Babel plugin verified — no custom `babel.config.js` exists; Expo SDK 54 + New Architecture handles reanimated v4 config automatically

## Test plan

- [x] `pnpm install` exits 0
- [x] `npx tsc --noEmit` passes
- [x] Confirmed no `babel.config.js` needed (Expo SDK 54 + New Arch + reactCompiler handles it)

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible)
- [x] No third-party SDKs added beyond task scope
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T1.2.5** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)