### PR TITLE
feat: gameStore start + answer actions, with tests (T2.3.1-T2.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — Implemented `gameStore` actions: `start(difficulty)` initialises a playing session and generates the first `Question`; `answer(choice)` applies scoring via `applyAnswer` and rolls a fresh question. `tick` and `reset` already in place. Selector subscriptions verified in `Timer` / `ScoreBadge` (completes T2.3.1, T2.3.2, T2.3.3).
 - **2026-05-02** — Implemented Phase 2 game logic primitives: `difficulty.ts` (operator pools + operand ranges), `questionGenerator.ts` (random arithmetic question with shuffled non-negative distractors and uuid v4 id), `scoring.ts` (pure `applyAnswer` reducer + `pointsFor` per difficulty) (completes T2.1.1, T2.1.2, T2.1.3).
 - **2026-05-02** — Created `src/features/game/index.ts` re-exporting the feature's public API (completes T1.7.3).
 - **2026-05-02** — Defined `Difficulty`, `Operator`, `GameState`, `Feedback`, `Question` types in `src/features/game/types/index.ts` (completes T1.7.2).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,8 +4,8 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 2 — Core Gameplay (in progress, ~18% complete)
-**Overall MVP progress:** ~40% (36 / 90 tasks complete)
+**Current phase:** Phase 2 — Core Gameplay (in progress, ~35% complete)
+**Overall MVP progress:** ~43% (39 / 90 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
 
@@ -17,7 +17,7 @@
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
 | **1** | Foundation — deps, theme, locales, skeleton, Uniwind/Tailwind styling | 🟡 In progress | ~100% |
-| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~18% |
+| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~35% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
 
@@ -120,6 +120,9 @@ Highlights of what will be delivered here:
 - [x] **T2.1.1** — `difficulty.ts` implemented (operatorPool + operandRange).
 - [x] **T2.1.2** — `questionGenerator.ts` implemented (random operands, distractors, shuffled choices, uuid v4).
 - [x] **T2.1.3** — `scoring.ts` implemented (pointsFor + pure applyAnswer reducer).
+- [x] **T2.3.1** — `gameStore.ts` full state shape implemented (already in place from Phase 1 stub).
+- [x] **T2.3.2** — `start`, `answer`, `tick`, `reset` actions implemented; `start` generates first question, `answer` reduces score via `applyAnswer` and rolls a fresh question.
+- [x] **T2.3.3** — Selector-based subscriptions verified in `Timer` and `ScoreBadge` (via `useGameStore((s) => …)`).
 
 ---
 

--- a/src/features/game/store/gameStore.test.ts
+++ b/src/features/game/store/gameStore.test.ts
@@ -1,0 +1,92 @@
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
+import { useGameStore } from '@/src/features/game/store/gameStore';
+import { pointsFor } from '@/src/features/game/lib/scoring';
+
+describe('useGameStore', () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  it('start(difficulty) puts the store into a playing state with defaults', () => {
+    useGameStore.getState().start('medium');
+    const s = useGameStore.getState();
+    expect(s.gameState).toBe('playing');
+    expect(s.score).toBe(0);
+    expect(s.timeRemaining).toBe(60);
+    expect(s.streak).toBe(0);
+    expect(s.lastFeedback).toBeNull();
+    expect(s.difficulty).toBe('medium');
+    expect(s.currentQuestion).not.toBeNull();
+  });
+
+  it('answer(correct) adds points, increments streak, sets feedback, replaces question', () => {
+    useGameStore.getState().start('hard');
+    const before = useGameStore.getState();
+    const prevQuestion = before.currentQuestion!;
+    useGameStore.getState().answer(prevQuestion.correct_answer);
+    const after = useGameStore.getState();
+    expect(after.score).toBe(before.score + pointsFor('hard'));
+    expect(after.streak).toBe(before.streak + 1);
+    expect(after.lastFeedback).toBe('correct');
+    expect(after.currentQuestion).not.toBeNull();
+    expect(after.currentQuestion).not.toBe(prevQuestion);
+  });
+
+  it('answer(wrong) keeps score, zeros streak, sets feedback to wrong, replaces question', () => {
+    useGameStore.getState().start('easy');
+    useGameStore.setState({ streak: 3, score: 5 });
+    const before = useGameStore.getState();
+    const prevQuestion = before.currentQuestion!;
+    const wrong = prevQuestion.correct_answer + 999;
+    useGameStore.getState().answer(wrong);
+    const after = useGameStore.getState();
+    expect(after.score).toBe(before.score);
+    expect(after.streak).toBe(0);
+    expect(after.lastFeedback).toBe('wrong');
+    expect(after.currentQuestion).not.toBeNull();
+    expect(after.currentQuestion).not.toBe(prevQuestion);
+  });
+
+  it('answer(...) is a no-op when gameState is idle', () => {
+    const before = useGameStore.getState();
+    useGameStore.getState().answer(42);
+    const after = useGameStore.getState();
+    expect(after.gameState).toBe(before.gameState);
+    expect(after.score).toBe(before.score);
+    expect(after.streak).toBe(before.streak);
+    expect(after.lastFeedback).toBe(before.lastFeedback);
+    expect(after.currentQuestion).toBe(before.currentQuestion);
+    expect(after.timeRemaining).toBe(before.timeRemaining);
+  });
+
+  it('tick() decrements timeRemaining by 1', () => {
+    useGameStore.getState().start('easy');
+    const before = useGameStore.getState().timeRemaining;
+    useGameStore.getState().tick();
+    expect(useGameStore.getState().timeRemaining).toBe(before - 1);
+  });
+
+  it('tick() from timeRemaining === 1 sets timeRemaining = 0 and gameState = game_over', () => {
+    useGameStore.getState().start('easy');
+    useGameStore.setState({ timeRemaining: 1 });
+    useGameStore.getState().tick();
+    const s = useGameStore.getState();
+    expect(s.timeRemaining).toBe(0);
+    expect(s.gameState).toBe('game_over');
+  });
+
+  it('reset() returns to defaults', () => {
+    useGameStore.getState().start('hard');
+    useGameStore.getState().tick();
+    useGameStore.getState().reset();
+    const s = useGameStore.getState();
+    expect(s.gameState).toBe('idle');
+    expect(s.score).toBe(0);
+    expect(s.timeRemaining).toBe(60);
+    expect(s.streak).toBe(0);
+    expect(s.lastFeedback).toBeNull();
+    expect(s.currentQuestion).toBeNull();
+    expect(s.difficulty).toBe('easy');
+  });
+});

--- a/src/features/game/store/gameStore.ts
+++ b/src/features/game/store/gameStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import type { Difficulty, GameState, Question, Feedback } from '@/src/features/game/types';
+import { generateQuestion } from '@/src/features/game/lib/questionGenerator';
+import { applyAnswer } from '@/src/features/game/lib/scoring';
 
 export interface GameStoreState {
   gameState: GameState;
@@ -20,10 +22,12 @@ export interface GameStoreActions {
 
 export type GameStore = GameStoreState & GameStoreActions;
 
+const ROUND_SECONDS = 60;
+
 const DEFAULT_STATE: GameStoreState = {
   gameState: 'idle',
   score: 0,
-  timeRemaining: 60,
+  timeRemaining: ROUND_SECONDS,
   currentQuestion: null,
   streak: 0,
   lastFeedback: null,
@@ -33,12 +37,40 @@ const DEFAULT_STATE: GameStoreState = {
 export const useGameStore = create<GameStore>((set) => ({
   ...DEFAULT_STATE,
 
-  start: (_difficulty: Difficulty) => {
-    throw new Error('gameStore.start not yet implemented (Phase 2 T2.3.2)');
+  start: (difficulty: Difficulty) => {
+    set({
+      gameState: 'playing',
+      score: 0,
+      timeRemaining: ROUND_SECONDS,
+      streak: 0,
+      lastFeedback: null,
+      difficulty,
+      currentQuestion: generateQuestion(difficulty),
+    });
   },
 
-  answer: (_choice: number) => {
-    throw new Error('gameStore.answer not yet implemented (Phase 2 T2.3.2)');
+  answer: (choice: number) => {
+    set((state) => {
+      if (state.gameState !== 'playing' || state.currentQuestion === null) {
+        return {};
+      }
+      const next = applyAnswer(
+        {
+          score: state.score,
+          streak: state.streak,
+          lastFeedback: state.lastFeedback,
+          difficulty: state.difficulty,
+        },
+        choice,
+        state.currentQuestion.correct_answer,
+      );
+      return {
+        score: next.score,
+        streak: next.streak,
+        lastFeedback: next.lastFeedback,
+        currentQuestion: generateQuestion(state.difficulty),
+      };
+    });
   },
 
   tick: () => {


### PR DESCRIPTION
## Summary

- **T2.3.1** — `gameStore` shape was already in place from the Phase 1 stub; reaffirmed and now backed by working actions.
- **T2.3.2** — Implemented `start(difficulty)` (sets playing state, resets score/streak/feedback, seeds first \`Question\` via \`generateQuestion\`, stores difficulty) and `answer(choice)` (calls \`applyAnswer\` with the current question's \`correct_answer\`, then rolls a fresh question; no-ops when not playing or no question loaded).
- **T2.3.3** — Selector subscriptions verified: `Timer` reads `(s) => s.timeRemaining` and `ScoreBadge` reads `(s) => s.score`. No bare `useGameStore()` calls in components.
- 7 new store tests added (action paths + idle no-op + reset). Total test count is now **25 / 4 suites**.

## Task

Implements **T2.3.1, T2.3.2, T2.3.3** from the Mathify MVP roadmap (Phase 2 — Core Gameplay). Full acceptance criteria are in [planned.md](planned.md).

## Acceptance criteria

- [x] `start(difficulty)` sets `gameState='playing'`, `score=0`, `timeRemaining=60`, `streak=0`, `lastFeedback=null`, `currentQuestion=generateQuestion(...)`, stores `difficulty`
- [x] `answer(choice)` calls `applyAnswer`, then replaces `currentQuestion` with a fresh one
- [x] `tick()` decrements `timeRemaining`; reaches 0 → `gameState='game_over'` (already in place)
- [x] `reset()` returns to idle defaults (already in place)
- [x] Components use selector-based subscriptions

## Test plan

- [x] `pnpm install` exits 0
- [x] `npx tsc --noEmit` passes
- [x] `pnpm test` — 4 suites / 25 tests, all green

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible, no unnecessary comments)
- [x] No third-party SDKs added beyond task scope
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T2.3.1, T2.3.2, T2.3.3** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)