### PR TITLE
feat: useGameLoop hook drives 1s tick interval (T2.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — `useGameLoop` hook drives the 1-second timer via `setInterval` while `gameState === 'playing'`; clears on state change or unmount (completes T2.4.1).
 - **2026-05-02** — Implemented `gameStore` actions: `start(difficulty)` initialises a playing session and generates the first `Question`; `answer(choice)` applies scoring via `applyAnswer` and rolls a fresh question. `tick` and `reset` already in place. Selector subscriptions verified in `Timer` / `ScoreBadge` (completes T2.3.1, T2.3.2, T2.3.3).
 - **2026-05-02** — Implemented Phase 2 game logic primitives: `difficulty.ts` (operator pools + operand ranges), `questionGenerator.ts` (random arithmetic question with shuffled non-negative distractors and uuid v4 id), `scoring.ts` (pure `applyAnswer` reducer + `pointsFor` per difficulty) (completes T2.1.1, T2.1.2, T2.1.3).
 - **2026-05-02** — Created `src/features/game/index.ts` re-exporting the feature's public API (completes T1.7.3).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,8 +4,8 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 2 — Core Gameplay (in progress, ~35% complete)
-**Overall MVP progress:** ~43% (39 / 90 tasks complete)
+**Current phase:** Phase 2 — Core Gameplay (in progress, ~41% complete)
+**Overall MVP progress:** ~44% (40 / 90 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
 
@@ -17,7 +17,7 @@
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
 | **1** | Foundation — deps, theme, locales, skeleton, Uniwind/Tailwind styling | 🟡 In progress | ~100% |
-| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~35% |
+| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~41% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
 
@@ -123,6 +123,7 @@ Highlights of what will be delivered here:
 - [x] **T2.3.1** — `gameStore.ts` full state shape implemented (already in place from Phase 1 stub).
 - [x] **T2.3.2** — `start`, `answer`, `tick`, `reset` actions implemented; `start` generates first question, `answer` reduces score via `applyAnswer` and rolls a fresh question.
 - [x] **T2.3.3** — Selector-based subscriptions verified in `Timer` and `ScoreBadge` (via `useGameStore((s) => …)`).
+- [x] **T2.4.1** — `useGameLoop` hook drives the 1s timer tick when playing.
 
 ---
 

--- a/src/features/game/hooks/useGameLoop.test.ts
+++ b/src/features/game/hooks/useGameLoop.test.ts
@@ -1,0 +1,68 @@
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
+import { act, renderHook } from '@testing-library/react-native';
+import { useGameLoop } from '@/src/features/game/hooks/useGameLoop';
+import { useGameStore } from '@/src/features/game/store/gameStore';
+
+describe('useGameLoop', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useGameStore.getState().reset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not tick when gameState is idle', () => {
+    renderHook(() => useGameLoop());
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(useGameStore.getState().timeRemaining).toBe(60);
+    expect(useGameStore.getState().gameState).toBe('idle');
+  });
+
+  it('ticks once per second when gameState is playing', () => {
+    act(() => {
+      useGameStore.getState().start('easy');
+    });
+    renderHook(() => useGameLoop());
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(useGameStore.getState().timeRemaining).toBe(57);
+  });
+
+  it('stops ticking when gameState transitions to game_over', () => {
+    act(() => {
+      useGameStore.getState().start('easy');
+    });
+    renderHook(() => useGameLoop());
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(useGameStore.getState().gameState).toBe('game_over');
+    expect(useGameStore.getState().timeRemaining).toBe(0);
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(useGameStore.getState().timeRemaining).toBe(0);
+  });
+
+  it('cleans up interval on unmount', () => {
+    act(() => {
+      useGameStore.getState().start('easy');
+    });
+    const { unmount } = renderHook(() => useGameLoop());
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    const beforeUnmount = useGameStore.getState().timeRemaining;
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(useGameStore.getState().timeRemaining).toBe(beforeUnmount);
+  });
+});

--- a/src/features/game/hooks/useGameLoop.ts
+++ b/src/features/game/hooks/useGameLoop.ts
@@ -1,30 +1,15 @@
 import { useEffect } from 'react';
 import { useGameStore } from '@/src/features/game/store/gameStore';
 
-// ---------------------------------------------------------------------------
-// Stub — full implementation in Phase 2 (T2.4.1)
-// ---------------------------------------------------------------------------
-
-/**
- * Drives the game timer while `gameState === 'playing'`.
- *
- * - Starts a 1-second interval that calls `tick()`.
- * - Clears the interval when `gameState` is no longer `'playing'`.
- * - Clears the interval on unmount.
- *
- * Mount this hook once at the top of the game screen.
- */
 export function useGameLoop(): void {
   const gameState = useGameStore((s) => s.gameState);
   const tick = useGameStore((s) => s.tick);
 
   useEffect(() => {
     if (gameState !== 'playing') return;
-
     const interval = setInterval(() => {
       tick();
     }, 1000);
-
     return () => clearInterval(interval);
   }, [gameState, tick]);
 }


### PR DESCRIPTION
## Summary

- Implemented \`useGameLoop()\`: subscribes to \`gameState\` + \`tick\` via selectors; while \`gameState === 'playing'\` runs a 1-second \`setInterval\` calling \`tick()\`; clears the interval on state change or unmount.
- The Phase 1 stub already had the working logic; this PR strips the stub comment headers per CLAUDE.md.
- 4 new hook tests added with jest fake timers + \`@testing-library/react-native\` \`renderHook\`. Total tests now **29 / 5 suites**, all green.

## Task

Implements **T2.4.1** from the Mathify MVP roadmap (Phase 2 — Core Gameplay). Full acceptance criteria are in [planned.md](planned.md).

## Acceptance criteria

- [x] On mount, if \`gameState === 'playing'\`, starts a 1-second \`setInterval\` calling \`tick()\`
- [x] On \`gameState !== 'playing'\`, clears the interval
- [x] On unmount, clears the interval
- [x] Uses \`useEffect\` with \`gameState\` as a dependency (also \`tick\` for exhaustive-deps)

## Test plan

- [x] \`pnpm install\` exits 0
- [x] \`npx tsc --noEmit\` passes
- [x] \`pnpm test\` — 5 suites / 29 tests, all green
- [x] Verified: idle → no tick; playing → 1Hz tick; game_over → halts; unmount → cleanup

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible, no unnecessary comments)
- [x] No third-party SDKs added beyond task scope
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T2.4.1** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)