### PR TITLE
feat: game screen components verified + tested (T2.5.1-T2.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — Game screen components verified for Phase 2: `QuestionCard`, `AnswerButton`, `Timer` (selector-subscribed to `timeRemaining`), `ScoreBadge` (selector-subscribed to `score`). Stub comments stripped from `AnswerButton` (completes T2.5.1, T2.5.2, T2.5.3, T2.5.4).
 - **2026-05-02** — `useGameLoop` hook drives the 1-second timer via `setInterval` while `gameState === 'playing'`; clears on state change or unmount (completes T2.4.1).
 - **2026-05-02** — Implemented `gameStore` actions: `start(difficulty)` initialises a playing session and generates the first `Question`; `answer(choice)` applies scoring via `applyAnswer` and rolls a fresh question. `tick` and `reset` already in place. Selector subscriptions verified in `Timer` / `ScoreBadge` (completes T2.3.1, T2.3.2, T2.3.3).
 - **2026-05-02** — Implemented Phase 2 game logic primitives: `difficulty.ts` (operator pools + operand ranges), `questionGenerator.ts` (random arithmetic question with shuffled non-negative distractors and uuid v4 id), `scoring.ts` (pure `applyAnswer` reducer + `pointsFor` per difficulty) (completes T2.1.1, T2.1.2, T2.1.3).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,8 +4,8 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 2 — Core Gameplay (in progress, ~41% complete)
-**Overall MVP progress:** ~44% (40 / 90 tasks complete)
+**Current phase:** Phase 2 — Core Gameplay (in progress, ~65% complete)
+**Overall MVP progress:** ~49% (44 / 90 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
 
@@ -17,7 +17,7 @@
 |---|---|---|---|
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
 | **1** | Foundation — deps, theme, locales, skeleton, Uniwind/Tailwind styling | 🟡 In progress | ~100% |
-| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~41% |
+| **2** | Core gameplay — playable round end-to-end | 🟡 In progress | ~65% |
 | **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
 
@@ -124,6 +124,10 @@ Highlights of what will be delivered here:
 - [x] **T2.3.2** — `start`, `answer`, `tick`, `reset` actions implemented; `start` generates first question, `answer` reduces score via `applyAnswer` and rolls a fresh question.
 - [x] **T2.3.3** — Selector-based subscriptions verified in `Timer` and `ScoreBadge` (via `useGameStore((s) => …)`).
 - [x] **T2.4.1** — `useGameLoop` hook drives the 1s timer tick when playing.
+- [x] **T2.5.1** — `QuestionCard` renders `{left} {op} {right} = ?` in display type.
+- [x] **T2.5.2** — `AnswerButton` wraps shared `Button`, emits `onPress(value)`.
+- [x] **T2.5.3** — `Timer` selector-subscribes to `timeRemaining`; renders seconds (red when ≤3).
+- [x] **T2.5.4** — `ScoreBadge` selector-subscribes to `score`; renders inside a primary-color pill.
 
 ---
 

--- a/src/features/game/components/AnswerButton.test.tsx
+++ b/src/features/game/components/AnswerButton.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { AnswerButton } from '@/src/features/game/components/AnswerButton';
+
+describe('AnswerButton', () => {
+  it('calls onPress with the numeric value when pressed', () => {
+    const onPress = jest.fn();
+    render(<AnswerButton value={42} onPress={onPress} />);
+    fireEvent.press(screen.getByText('42'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(42);
+  });
+
+  it('does not call onPress when disabled', () => {
+    const onPress = jest.fn();
+    render(<AnswerButton value={7} onPress={onPress} disabled />);
+    fireEvent.press(screen.getByText('7'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/game/components/AnswerButton.tsx
+++ b/src/features/game/components/AnswerButton.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
 import { Button } from '@/src/shared/components';
 
-// ---------------------------------------------------------------------------
-// Stub — full implementation in Phase 2 (T2.5.2)
-// ---------------------------------------------------------------------------
-
 export interface AnswerButtonProps {
   value: number;
   onPress: (value: number) => void;
   disabled?: boolean;
 }
 
-/**
- * A large, accessible button that the player taps to submit an answer.
- * Wraps the shared `Button` primitive with game-specific behaviour.
- */
 export function AnswerButton({ value, onPress, disabled = false }: AnswerButtonProps) {
   return (
     <Button

--- a/src/features/game/components/QuestionCard.test.tsx
+++ b/src/features/game/components/QuestionCard.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { QuestionCard } from '@/src/features/game/components/QuestionCard';
+import type { Question } from '@/src/features/game/types';
+
+describe('QuestionCard', () => {
+  it('renders the equation text including operands and operator', () => {
+    const question: Question = {
+      id: 'q1',
+      operand_left: 3,
+      operator: '+',
+      operand_right: 5,
+      correct_answer: 8,
+      answer_choices: [8, 7, 9, 10],
+    };
+    render(<QuestionCard question={question} />);
+    expect(screen.getByText('3 + 5 = ?')).toBeTruthy();
+  });
+});

--- a/src/features/game/components/ScoreBadge.test.tsx
+++ b/src/features/game/components/ScoreBadge.test.tsx
@@ -1,0 +1,18 @@
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { ScoreBadge } from '@/src/features/game/components/ScoreBadge';
+import { useGameStore } from '@/src/features/game/store/gameStore';
+
+describe('ScoreBadge', () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  it('renders the current score from the store', () => {
+    useGameStore.setState({ score: 17 });
+    render(<ScoreBadge />);
+    expect(screen.getByText('17')).toBeTruthy();
+  });
+});

--- a/src/features/game/components/Timer.test.tsx
+++ b/src/features/game/components/Timer.test.tsx
@@ -1,0 +1,33 @@
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
+import React from 'react';
+import { act, render, screen } from '@testing-library/react-native';
+import { Timer } from '@/src/features/game/components/Timer';
+import { useGameStore } from '@/src/features/game/store/gameStore';
+
+describe('Timer', () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  it('renders timeRemaining from the store with an "s" suffix', () => {
+    useGameStore.setState({ timeRemaining: 42 });
+    render(<Timer />);
+    expect(screen.getByText('42s')).toBeTruthy();
+  });
+
+  it('applies the danger color class when timeRemaining <= 3 (urgent)', () => {
+    useGameStore.setState({ timeRemaining: 2 });
+    render(<Timer />);
+    const urgent = screen.getByText('2s');
+    expect(urgent.props.className).toContain('text-danger');
+
+    act(() => {
+      useGameStore.setState({ timeRemaining: 30 });
+    });
+    render(<Timer />);
+    const calm = screen.getByText('30s');
+    expect(calm.props.className).not.toContain('text-danger');
+    expect(calm.props.className).toContain('text-text-primary');
+  });
+});


### PR DESCRIPTION
## Summary

All four game screen components were already in place from Phase 1 stub scaffolding and the Uniwind/Tailwind migration. This PR verifies their behavior matches Phase 2 acceptance criteria, strips the lingering stub comment block from \`AnswerButton.tsx\`, and adds component tests.

- **T2.5.1 — \`QuestionCard\`** — renders \`{operand_left} {operator} {operand_right} = ?\` in display type. ✓
- **T2.5.2 — \`AnswerButton\`** — wraps shared \`Button\`, emits \`onPress(value)\`. ✓
- **T2.5.3 — \`Timer\`** — selector-subscribes to \`(s) => s.timeRemaining\` only; renders \`{n}s\`; turns red when ≤3s. ✓
- **T2.5.4 — \`ScoreBadge\`** — selector-subscribes to \`(s) => s.score\` only; renders inside a primary-color pill. ✓
- 6 new tests added across 4 component test files. Total **35 / 9 suites**, all green.

## Task

Implements **T2.5.1, T2.5.2, T2.5.3, T2.5.4** from the Mathify MVP roadmap (Phase 2 — Core Gameplay). Full acceptance criteria are in [planned.md](planned.md).

## Acceptance criteria

- [x] \`QuestionCard\` renders \`{operand_left} {operator} {operand_right} = ?\`
- [x] \`AnswerButton\` calls \`onPress(value)\` when pressed; respects \`disabled\`
- [x] \`Timer\` subscribes via selector to \`timeRemaining\`; renders seconds; urgent state when ≤3
- [x] \`ScoreBadge\` subscribes via selector to \`score\`; renders current score

## Test plan

- [x] \`pnpm install\` exits 0
- [x] \`npx tsc --noEmit\` passes
- [x] \`pnpm test\` — 9 suites / 35 tests, all green

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible, no unnecessary comments)
- [x] No third-party SDKs added beyond task scope
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T2.5.1, T2.5.2, T2.5.3, T2.5.4** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)