### PR TITLE
feat: persisted prefsStore (T3.4.1-T3.4.4) — Phase 3 foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ### Added
 
+- **2026-05-02** — Created persisted `prefsStore` at `src/shared/store/prefsStore.ts`: Zustand + `persist` middleware over AsyncStorage; Zod-validated rehydrate with `DEFAULT_PREFS` fallback; actions for language (also calls `i18next.changeLanguage`), difficulty, sound, haptics, and per-difficulty high-score recording (completes T3.4.1, T3.4.2, T3.4.3, T3.4.4).
 - **2026-05-02** — Phase 2 routes wired: `src/app/index.tsx` (Home) replaces the template stub with i18n title, difficulty `SegmentedControl`, Start button; `src/app/game.tsx` (Game) mounts `useGameLoop` and renders the playing UI, navigates to `/game-over` on `game_over`; `src/app/game-over.tsx` (Game Over) shows final score with Replay + Home buttons; `src/app/_layout.tsx` registers all three with `headerShown: false` and `gestureEnabled: false` on the game screens. This completes Phase 2 — a full playable round end-to-end (completes T2.6.1, T2.6.2, T2.6.3, T2.6.4).
 - **2026-05-02** — Game screen components verified for Phase 2: `QuestionCard`, `AnswerButton`, `Timer` (selector-subscribed to `timeRemaining`), `ScoreBadge` (selector-subscribed to `score`). Stub comments stripped from `AnswerButton` (completes T2.5.1, T2.5.2, T2.5.3, T2.5.4).
 - **2026-05-02** — `useGameLoop` hook drives the 1-second timer via `setInterval` while `gameState === 'playing'`; clears on state change or unmount (completes T2.4.1).

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -4,8 +4,8 @@
 > Source of truth for milestones: [planned.md](planned.md). Source of truth for completed history: [CHANGELOG.md](CHANGELOG.md).
 
 **Last updated:** 2026-05-02
-**Current phase:** Phase 3 — Feel & Polish (not yet started)
-**Overall MVP progress:** ~53% (48 / 90 tasks complete)
+**Current phase:** Phase 3 — Feel & Polish (in progress, ~24% complete)
+**Overall MVP progress:** ~58% (52 / 90 tasks complete)
 **Next release target:** v1.0.0 — App Store + Play Store (end of Phase 4)
 **Active blockers:** None
 
@@ -18,7 +18,7 @@
 | **0** | Project bootstrap (pre-MVP scaffold) | ✅ Complete | 100% |
 | **1** | Foundation — deps, theme, locales, skeleton, Uniwind/Tailwind styling | 🟡 In progress | ~100% |
 | **2** | Core gameplay — playable round end-to-end | ✅ Complete | 100% |
-| **3** | Feel & polish — animation, audio, haptics, persistence, a11y | ⏳ Not started | 0% |
+| **3** | Feel & polish — animation, audio, haptics, persistence, a11y | 🟡 In progress | ~24% |
 | **4** | Release — EAS, store assets, submission | ⏳ Not started | 0% |
 
 ---
@@ -139,7 +139,7 @@ Highlights of what will be delivered here:
 
 ---
 
-## Phase 3 — Feel & Polish (⏳ Not started)
+## Phase 3 — Feel & Polish (🟡 In progress)
 
 **Goal:** Convert "playable" into "fun" — feedback flashes, audio, haptics, persisted high score per difficulty, language toggle, and accessibility pass.
 
@@ -150,6 +150,13 @@ Highlights:
 - `prefsStore` (Zustand `persist` + AsyncStorage) with Zod rehydration validation.
 - High score persisted per difficulty.
 - VoiceOver / TalkBack pass and WCAG AA contrast verification.
+
+### Accomplished
+
+- [x] **T3.4.1** — `prefsStore.ts` created with Zod schema covering `language`, `last_difficulty`, `sound_enabled`, `haptics_enabled`, `high_score`.
+- [x] **T3.4.2** — Wrapped store with Zustand `persist` middleware using AsyncStorage as storage adapter.
+- [x] **T3.4.3** — Custom `merge` runs `PrefsSchema.safeParse`; falls back to `DEFAULT_PREFS` on failure with a single `__DEV__` warning.
+- [x] **T3.4.4** — Actions implemented: `setLanguage` (also calls `i18n.changeLanguage`), `setDifficulty`, `setSoundEnabled`, `setHapticsEnabled`, `recordScore` (writes only if higher than current best).
 
 ---
 

--- a/src/shared/store/prefsStore.test.ts
+++ b/src/shared/store/prefsStore.test.ts
@@ -1,0 +1,106 @@
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+const mockChangeLanguage = jest.fn();
+jest.mock('@/src/shared/config/i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: (...args: unknown[]) => mockChangeLanguage(...args) },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => {
+        store[key] = value;
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+        return Promise.resolve();
+      }),
+      clear: jest.fn(() => {
+        for (const k of Object.keys(store)) delete store[k];
+        return Promise.resolve();
+      }),
+      getAllKeys: jest.fn(() => Promise.resolve(Object.keys(store))),
+      multiGet: jest.fn((keys: string[]) =>
+        Promise.resolve(keys.map((k) => [k, store[k] ?? null])),
+      ),
+      multiSet: jest.fn((pairs: [string, string][]) => {
+        for (const [k, v] of pairs) store[k] = v;
+        return Promise.resolve();
+      }),
+      multiRemove: jest.fn((keys: string[]) => {
+        for (const k of keys) delete store[k];
+        return Promise.resolve();
+      }),
+    },
+  };
+});
+
+import { usePrefsStore, DEFAULT_PREFS } from '@/src/shared/store/prefsStore';
+
+describe('usePrefsStore', () => {
+  beforeEach(() => {
+    mockChangeLanguage.mockClear();
+    usePrefsStore.setState({ ...DEFAULT_PREFS });
+  });
+
+  it('has correct defaults on a fresh store', () => {
+    const s = usePrefsStore.getState();
+    expect(s.language).toBe('en');
+    expect(s.last_difficulty).toBe('easy');
+    expect(s.sound_enabled).toBe(true);
+    expect(s.haptics_enabled).toBe(true);
+    expect(s.high_score).toEqual({ easy: 0, medium: 0, hard: 0 });
+  });
+
+  it('setLanguage("fr") updates state and calls i18n.changeLanguage', () => {
+    usePrefsStore.getState().setLanguage('fr');
+    expect(usePrefsStore.getState().language).toBe('fr');
+    expect(mockChangeLanguage).toHaveBeenCalledTimes(1);
+    expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
+  });
+
+  it('setDifficulty("hard") updates last_difficulty', () => {
+    usePrefsStore.getState().setDifficulty('hard');
+    expect(usePrefsStore.getState().last_difficulty).toBe('hard');
+  });
+
+  it('setSoundEnabled(false) updates sound_enabled', () => {
+    usePrefsStore.getState().setSoundEnabled(false);
+    expect(usePrefsStore.getState().sound_enabled).toBe(false);
+  });
+
+  it('setHapticsEnabled(false) updates haptics_enabled', () => {
+    usePrefsStore.getState().setHapticsEnabled(false);
+    expect(usePrefsStore.getState().haptics_enabled).toBe(false);
+  });
+
+  it('recordScore("medium", 10) on a fresh store sets the high score to 10', () => {
+    usePrefsStore.getState().recordScore('medium', 10);
+    expect(usePrefsStore.getState().high_score.medium).toBe(10);
+  });
+
+  it('recordScore does not lower an existing high score', () => {
+    usePrefsStore.getState().recordScore('medium', 10);
+    usePrefsStore.getState().recordScore('medium', 5);
+    expect(usePrefsStore.getState().high_score.medium).toBe(10);
+  });
+
+  it('recordScore updates when the new score is higher', () => {
+    usePrefsStore.getState().recordScore('medium', 10);
+    usePrefsStore.getState().recordScore('medium', 15);
+    expect(usePrefsStore.getState().high_score.medium).toBe(15);
+  });
+
+  it('recordScore only touches the requested difficulty', () => {
+    usePrefsStore.getState().recordScore('medium', 10);
+    const s = usePrefsStore.getState();
+    expect(s.high_score.easy).toBe(0);
+    expect(s.high_score.hard).toBe(0);
+    expect(s.high_score.medium).toBe(10);
+  });
+});

--- a/src/shared/store/prefsStore.ts
+++ b/src/shared/store/prefsStore.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { z } from 'zod';
+import i18n from '@/src/shared/config/i18n';
+import type { Difficulty } from '@/src/features/game/types';
+
+const PrefsSchema = z.object({
+  language: z.enum(['en', 'fr']),
+  last_difficulty: z.enum(['easy', 'medium', 'hard']),
+  sound_enabled: z.boolean(),
+  haptics_enabled: z.boolean(),
+  high_score: z.object({
+    easy: z.number().int().nonnegative(),
+    medium: z.number().int().nonnegative(),
+    hard: z.number().int().nonnegative(),
+  }),
+});
+
+export type Prefs = z.infer<typeof PrefsSchema>;
+
+export const DEFAULT_PREFS: Prefs = {
+  language: 'en',
+  last_difficulty: 'easy',
+  sound_enabled: true,
+  haptics_enabled: true,
+  high_score: { easy: 0, medium: 0, hard: 0 },
+};
+
+export interface PrefsActions {
+  setLanguage: (lang: Prefs['language']) => void;
+  setDifficulty: (d: Difficulty) => void;
+  setSoundEnabled: (b: boolean) => void;
+  setHapticsEnabled: (b: boolean) => void;
+  recordScore: (d: Difficulty, score: number) => void;
+}
+
+export type PrefsStore = Prefs & PrefsActions;
+
+const STORAGE_KEY = 'mathify-prefs';
+
+export const usePrefsStore = create<PrefsStore>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULT_PREFS,
+
+      setLanguage: (lang) => {
+        set({ language: lang });
+        i18n.changeLanguage(lang);
+      },
+
+      setDifficulty: (d) => {
+        set({ last_difficulty: d });
+      },
+
+      setSoundEnabled: (b) => {
+        set({ sound_enabled: b });
+      },
+
+      setHapticsEnabled: (b) => {
+        set({ haptics_enabled: b });
+      },
+
+      recordScore: (d, score) => {
+        const current = get().high_score[d];
+        if (score > current) {
+          set({ high_score: { ...get().high_score, [d]: score } });
+        }
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => AsyncStorage),
+      merge: (persistedState, currentState) => {
+        const parsed = PrefsSchema.safeParse(persistedState);
+        if (!parsed.success) {
+          if (__DEV__) {
+            console.warn('[prefsStore] rehydrate validation failed; falling back to defaults', parsed.error);
+          }
+          return { ...currentState, ...DEFAULT_PREFS };
+        }
+        return { ...currentState, ...parsed.data };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

First Phase 3 PR — lays the persistence foundation that the audio, haptics, and screen-wiring waves all depend on.

- **T3.4.1** — \`src/shared/store/prefsStore.ts\` defines a Zod schema covering \`language\` ('en'|'fr'), \`last_difficulty\` (Difficulty), \`sound_enabled\` (bool, default true), \`haptics_enabled\` (bool, default true), \`high_score: Record<Difficulty, number>\` (defaults 0).
- **T3.4.2** — Wrapped with Zustand \`persist\` middleware via \`createJSONStorage(() => AsyncStorage)\`. Storage key: \`mathify-prefs\`.
- **T3.4.3** — Custom \`merge\` runs \`PrefsSchema.safeParse(persistedState)\`. On failure, falls back to \`DEFAULT_PREFS\` and logs a single \`__DEV__\` warning. Guards against corrupt or schema-drifted AsyncStorage payloads.
- **T3.4.4** — Actions: \`setLanguage(lang)\` (also calls \`i18n.changeLanguage\`), \`setDifficulty(d)\`, \`setSoundEnabled(b)\`, \`setHapticsEnabled(b)\`, \`recordScore(d, score)\` — only writes when \`score > current high_score[d]\`.
- 9 new unit tests added. **Total 50 / 13 suites**, all green.

## Task

Implements **T3.4.1, T3.4.2, T3.4.3, T3.4.4** from the Mathify MVP roadmap (Phase 3 — Feel & Polish). Full acceptance criteria are in [planned.md](planned.md).

## Acceptance criteria

- [x] \`prefsStore.ts\` defines schema and defaults per architecture.md §4.2
- [x] Wrapped with Zustand \`persist\` middleware over AsyncStorage
- [x] Zod \`safeParse\` rehydrate validation with default fallback + dev warning
- [x] Actions: setLanguage (+ i18next), setDifficulty, setSoundEnabled, setHapticsEnabled, recordScore (only if higher)

## Test plan

- [x] \`pnpm install\` exits 0
- [x] \`npx tsc --noEmit\` passes
- [x] \`pnpm test\` — 13 suites / 50 tests, all green

## Notes

- \`@react-native-async-storage/async-storage\` v3.0.2 doesn't ship a Jest mock file, so the test uses an inline in-memory mock. (Not a blocker for production; only test-time concern.)
- The Zod fallback path is exercised on every test load (rehydrate sees empty AsyncStorage and triggers the \`!parsed.success\` branch). \`console.warn\` is silenced in the test file to keep output clean. A more rigorous fallback test would require exporting the merge function — flagged for follow-up if needed.

## Checklist

- [x] Follows CLAUDE.md conventions (pnpm, strict TS, New Arch compatible, no unnecessary comments)
- [x] No third-party SDKs added beyond task scope (all deps already installed in T1.2)
- [x] PROJECT_STATUS.md and CHANGELOG.md updated

---

Completes **T3.4.1, T3.4.2, T3.4.3, T3.4.4** · [planned.md](planned.md)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)